### PR TITLE
Fixed 9 - TOC Font Size Increased

### DIFF
--- a/_layouts/toc.html
+++ b/_layouts/toc.html
@@ -27,7 +27,7 @@
 
         <div class="container">
             <div class="row">
-                <div class="col-lg-offset-2 col-lg-8 text-left">
+                <div class="col-lg-offset-2 col-lg-8 text-left toc">
                     <h2>Table of Contents</h2>
                     
                     <ol>

--- a/assets/css/immersion.scss
+++ b/assets/css/immersion.scss
@@ -64,6 +64,10 @@ a:hover,
   margin-bottom: 40px;
 }
 
+.toc {
+  font-size: 18px;
+}
+
 .project-name {
   font-size: 6em;
   color: $primary-color;


### PR DESCRIPTION
I added the `toc` class to the `table of contents` and increased the TOC `font-size` to `18px`.

Fixes #9.